### PR TITLE
Sort present dates according to `decreasing`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -39,9 +39,9 @@ format_date <- function(data,
 
   # Sort
   if (sort_by == "start") {
-    data <- data[order(data[[start]], decreasing = decreasing), ]
+    data <- data[order(data[[start]], na.last = !decreasing, decreasing = decreasing), ]
   } else if (sort_by == "end" && !is.null(end)) {
-    data <- data[order(data[[end]], decreasing = decreasing), ]
+    data <- data[order(data[[end]], na.last = !decreasing, decreasing = decreasing), ]
   } else if (sort_by == "none") {
     # Do nothing
   } else {


### PR DESCRIPTION
Format dates currently sorts present dates (which are na's) always last, but this yields counter-intuitive results when `decreasing = TRUE`:

```r
work <- data.frame(
  title = c("Technical Assistant", "Junior Professor", "Associate Professor"),
  location = c("Bern, Switzerland", "Bern, Switzerland", "Zürich, Switzerland"),
  start = as.Date(c("1902-01-01", "1908-01-01", "1909-01-01")),
  end = as.Date(c("1908-01-01", "1909-01-01", NA)),
  description = c("Federal Patent Office", "University of Bern", "University of Zürich")
)

work |>
  format_date(end = "end", date_format = "%Y", sort_by = "end", decreasing = TRUE) |>
  resume_entry()
#> ```{=typst}
#> #resume-entry(title: "Junior Professor",location: "Bern, Switzerland",date: "1908 - 1909",description: "University of Bern",)
#> #resume-entry(title: "Technical Assistant",location: "Bern, Switzerland",date: "1902 - 1908",description: "Federal Patent Office",)
#> #resume-entry(title: "Associate Professor",location: "Zürich, Switzerland",date: "1909 - Present",description: "University of Zürich",)
#> ```
```

This change sets `na.last` to the opposite of decreasing so present dates will be first when `decreasing = TRUE` and last when `decreasing = FALSE` 